### PR TITLE
feat(tz): inject timezone into datetime skeletons

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 16, 18, 19 ]
+        node: [ 16, 18, 20 ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v3
@@ -42,7 +42,7 @@ jobs:
 #        env:
 #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish package
-        if: ${{ matrix.node == '18' }}
+        if: ${{ matrix.node == '20' }}
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/example/compiled/bundle_en.compiled.json
+++ b/example/compiled/bundle_en.compiled.json
@@ -33,7 +33,8 @@
         "parsedOptions": {
           "hour": "2-digit",
           "hourCycle": "h23",
-          "minute": "2-digit"
+          "minute": "2-digit",
+          "timeZone": "Europe/Oslo"
         },
         "pattern": "HHmm",
         "type": 1
@@ -49,7 +50,8 @@
       "style": {
         "parsedOptions": {
           "day": "2-digit",
-          "month": "short"
+          "month": "short",
+          "timeZone": "Europe/Oslo"
         },
         "pattern": "ddMMM",
         "type": 1

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prepare": "husky install",
     "commit": "git-cz",
     "test": "vitest --coverage",
-    "test-local": "node lib/index.js build example/messages example/compiled -f formatjs --ast --lut --strict --typescript",
+    "test-local": "node lib/index.js build example/messages example/compiled -f formatjs --ast --lut --strict --typescript --timeZone Europe/Oslo",
     "build": "rm -rf lib && tsc -p ."
   },
   "author": "Nicklas Utgaard",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -44,6 +44,7 @@ export default class Build {
                 const compiledFilename = path.join(config.outDir, `bundle_${locale}.compiled.json`);
                 const compiledBundle = await compile([filename], {
                     ast: true,
+                    timeZone: config.timeZone,
                 });
                 fs.writeFileSync(compiledFilename, compiledBundle, { encoding: 'utf-8' });
             }

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export interface BuildOptions {
     strict: boolean;
     ast: boolean;
     lut: boolean;
+    timeZone?: string;
     exitOnError?: boolean;
     hasFixerListener?: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ program
     .option('--strict', 'Run validation before bundling', { default: false })
     .option('--ast', 'Compile generated bundles (only availble with formatjs)', { default: false })
     .option('--lut', 'Generate look-up-table', { default: false })
+    .option('-t, --timeZone <timezone>', 'Inject timezone into date/time skeletons')
     .action(({ logger, args, options }) => {
         BuildCmd.run(logger, { ...args, ...options } as unknown as BuildOptions);
     });

--- a/test/commands/__snapshots__/build.test.ts.snap
+++ b/test/commands/__snapshots__/build.test.ts.snap
@@ -137,3 +137,62 @@ export function createIntlLUT(intl: IntlShape<React.ReactNode>) {
 }",
 }
 `;
+
+exports[`build command > should should inject timezone into skeletons 1`] = `
+{
+  "/app/compiled/bundle_en.compiled.json": "{
+  \\"date\\": [
+    {
+      \\"type\\": 0,
+      \\"value\\": \\"starts \\"
+    },
+    {
+      \\"style\\": {
+        \\"parsedOptions\\": {
+          \\"day\\": \\"2-digit\\",
+          \\"month\\": \\"short\\",
+          \\"timeZone\\": \\"Europe/Oslo\\"
+        },
+        \\"pattern\\": \\"ddMMM\\",
+        \\"type\\": 1
+      },
+      \\"type\\": 3,
+      \\"value\\": \\"date\\"
+    },
+    {
+      \\"type\\": 0,
+      \\"value\\": \\" at \\"
+    },
+    {
+      \\"style\\": {
+        \\"parsedOptions\\": {
+          \\"hour\\": \\"2-digit\\",
+          \\"hourCycle\\": \\"h23\\",
+          \\"minute\\": \\"2-digit\\",
+          \\"timeZone\\": \\"Europe/Oslo\\"
+        },
+        \\"pattern\\": \\"HHmm\\",
+        \\"type\\": 1
+      },
+      \\"type\\": 3,
+      \\"value\\": \\"date\\"
+    }
+  ]
+}",
+  "/app/compiled/bundle_en.json": "{
+  \\"date\\": {
+    \\"defaultMessage\\": \\"starts { date, date, ::ddMMM } at { date, date, ::HHmm }\\"
+  }
+}",
+  "/app/compiled/lut.ts": "import React from \\"react\\";
+import {IntlShape} from \\"@formatjs/intl\\";
+// @ts-ignore
+import {FormatXMLElementFn} from \\"intl-messageformat\\";
+
+export function createIntlLUT(intl: IntlShape<React.ReactNode>) {
+  return {
+    \\"date\\": (args: { date: Date }) => intl.formatMessage({ id: 'date' }, {date: args.date}),
+  }
+}",
+}
+`;

--- a/test/commands/build.test.ts
+++ b/test/commands/build.test.ts
@@ -94,6 +94,27 @@ describe('build command', () => {
         expect(vol.toJSON('/app/compiled')).toMatchSnapshot();
     });
 
+    it('should should inject timezone into skeletons', async () => {
+        vol.fromNestedJSON(
+            {
+                'date_en.txt': 'starts { date, date, ::ddMMM } at { date, date, ::HHmm }',
+            },
+            '/app/messages',
+        );
+
+        await Build.run(createLogger(), {
+            ...defaultConfig,
+            strict: true,
+            typescript: true,
+            ast: true,
+            lut: true,
+            format: 'formatjs',
+            timeZone: 'Europe/Oslo',
+        });
+
+        expect(vol.toJSON('/app/compiled')).toMatchSnapshot();
+    });
+
     it('should throw error if validation is enabled and texts mismatch', async () => {
         vol.fromNestedJSON(
             {


### PR DESCRIPTION
due to limitations in formatjs it is not possible to control timezone when using date/time skeletons
(see https://github.com/formatjs/formatjs/issues/3971#issuecomment-1407959300 ). This change makes
it possible to inject timezone at compile time to bypass this issue
